### PR TITLE
Use gpio number with gpiochip name

### DIFF
--- a/revpi_provisioning/hat.py
+++ b/revpi_provisioning/hat.py
@@ -1,6 +1,7 @@
 class HatEEPROM:
-    def __init__(self,  write_protect_gpio: int) -> None:
+    def __init__(self,  write_protect_gpio: int, gpio_chip: str = "gpiochip0") -> None:
         self.write_protect_gpio = write_protect_gpio
+        self.gpio_chip = gpio_chip
 
     def _write_image(self, eeprom_image: str):
         print(f"write hat eeprom with image '{eeprom_image}'")


### PR DESCRIPTION
A GPIO is specified as a pin number of a specific gpiochip. Therefore we want to make the gpiochip name configurable aswell.

As mentioned by @iluminat23 in #1 