### PR TITLE
Always call set_mac_address()

### DIFF
--- a/revpi_provisioning/revpi.py
+++ b/revpi_provisioning/revpi.py
@@ -22,7 +22,7 @@ class RevPi:
         mac_address = MacAddress(first_mac_address)
         mac_addresses = []
 
-        for index, interface in enumerate(filter(lambda i: i.has_eeprom, self.network_interfaces)):
+        for interface in self.network_interfaces:
             interface.set_mac_address(mac_address)
             mac_addresses.append(mac_address)
 


### PR DESCRIPTION
In order to enumerate the mac addresses correctly for all interfaces (regardless EEPROM attached or not), we must call set_mac_address() for legacy interfaces without an EEPROM too.

As mentioned by @iluminat23 in #1 