### PR TITLE
Write USB ethernet EEPROM with helper scripts [REVPI-2710]

### DIFF
--- a/revpi_provisioning/network/__init__.py
+++ b/revpi_provisioning/network/__init__.py
@@ -9,6 +9,10 @@ NETWORK_INTERFACE_TYPES = {
 }
 
 
+class NetworkEEPROMException(Exception):
+    pass
+
+
 class InvalidNetworkInterfaceTypeString(Exception):
     pass
 


### PR DESCRIPTION
Write mac address to USB ethernet EEPROM by calling the helper scripts we created earlier for this task. The scripts are part of our official image and therefore can be safely expected on the target.
