### PR TITLE
Improve product number extraction

### DIFF
--- a/provisioner.py
+++ b/provisioner.py
@@ -4,13 +4,7 @@ from revpi_provisioning.hat import HatEEPROM
 from revpi_provisioning.network import find_interface_class
 from revpi_provisioning.network.usb import LAN95XXNetworkInterface
 from revpi_provisioning.revpi import RevPi
-
-
-def _extract_product(product_number: str) -> tuple:
-    product_id = int(product_number[2:8])
-    revision = int(product_number[9:11])
-    return (product_id, revision)
-
+from revpi_provisioning.utils import extract_product
 
 if __name__ == "__main__":
     import argparse
@@ -28,10 +22,9 @@ if __name__ == "__main__":
     mac = args.mac_address
     image_path = args.eep_image
 
-    _extract_product(product)
     ####################### FROM TEMPLATE - BEGIN #############################
     # define product
-    revpi = RevPi(*_extract_product(product))
+    revpi = RevPi(*extract_product(product))
 
     # define HAT EEPROM
     revpi.hat_eeprom = HatEEPROM(22)

--- a/revpi_provisioning/utils.py
+++ b/revpi_provisioning/utils.py
@@ -5,6 +5,13 @@ class InvalidMacAddressFormat(Exception):
     pass
 
 
+class InvalidProductNumberException(Exception):
+    def __init__(self, product_number: str):
+        self.product_number = product_number
+
+        super().__init__(f"Could not parse product number: {product_number}")
+
+
 class MacAddress:
     """MAC address representation class with some helper methods"""
 
@@ -55,3 +62,12 @@ class MacAddress:
     @property
     def nic(self) -> str:
         return str(self)[6:]
+
+
+def extract_product(product_number: str) -> tuple:
+    product_match = re.match(r'^PR([0-9]{6})R([0-9]{2})$', product_number, re.IGNORECASE)
+
+    if product_match:
+        return product_match.groups()
+
+    raise InvalidProductNumberException(product_number)


### PR DESCRIPTION
The current implementation does not check for product number format and therefore will fail with input like 'PR1000299R01' (too long) or other invalid formats. In order to fix this, the product number extraction has been reimplemented with regexp. If the product number format is invalid an InvalidProductNumberException is raised.
