### PR TITLE
Do not import provisioner in validator

### DIFF
--- a/validate-config.py
+++ b/validate-config.py
@@ -3,9 +3,15 @@
 import argparse
 import os
 import yaml
+import sys
 
-from provisioner import error, SchemaError
+from schema import SchemaError
 from config import config_schema
+
+def error(msg: str, rc: int):
+    print(msg, file=sys.stderr)
+    sys.exit(rc)
+
 
 parser = argparse.ArgumentParser(
     description="Validate device configuration file")


### PR DESCRIPTION
Directly import SchemaError from schema and define error() in validator. If provisioner is imported, the validation script will fail due to absence of gpiod. The latter is not present in our CI pipeline (and would not make sense there too).

This fixes the CI validation job (see https://github.com/RevolutionPi/revpi-eol-provisioner/pull/6)