### PR TITLE
[RevPi-2607] Made symlinks to copied files

### DIFF
--- a/revpi_provisioning/devices/PR100299R00.yaml
+++ b/revpi_provisioning/devices/PR100299R00.yaml
@@ -1,1 +1,5 @@
-_core.yaml
+---
+network_interfaces:
+  - type: lan95xx
+    path: 1-1.1:1.0
+    eeprom: False

--- a/revpi_provisioning/devices/PR100299R01.yaml
+++ b/revpi_provisioning/devices/PR100299R01.yaml
@@ -1,1 +1,9 @@
-_core-2022.yaml
+---
+hat_eeprom:
+  wp_gpio: 2
+  wp_gpiochip: gpiochip0
+
+network_interfaces:
+  - type: lan95xx
+    path: 1-1.1:1.0
+    eeprom: True

--- a/revpi_provisioning/devices/PR100300R00.yaml
+++ b/revpi_provisioning/devices/PR100300R00.yaml
@@ -1,1 +1,5 @@
-_core.yaml
+---
+network_interfaces:
+  - type: lan95xx
+    path: 1-1.1:1.0
+    eeprom: False

--- a/revpi_provisioning/devices/PR100300R01.yaml
+++ b/revpi_provisioning/devices/PR100300R01.yaml
@@ -1,1 +1,9 @@
-_core-2022.yaml
+---
+hat_eeprom:
+  wp_gpio: 2
+  wp_gpiochip: gpiochip0
+
+network_interfaces:
+  - type: lan95xx
+    path: 1-1.1:1.0
+    eeprom: True

--- a/revpi_provisioning/devices/PR100301R00.yaml
+++ b/revpi_provisioning/devices/PR100301R00.yaml
@@ -1,1 +1,5 @@
-_core.yaml
+---
+network_interfaces:
+  - type: lan95xx
+    path: 1-1.1:1.0
+    eeprom: False

--- a/revpi_provisioning/devices/PR100301R01.yaml
+++ b/revpi_provisioning/devices/PR100301R01.yaml
@@ -1,1 +1,9 @@
-_core-2022.yaml
+---
+hat_eeprom:
+  wp_gpio: 2
+  wp_gpiochip: gpiochip0
+
+network_interfaces:
+  - type: lan95xx
+    path: 1-1.1:1.0
+    eeprom: True

--- a/revpi_provisioning/devices/PR100359R00.yaml
+++ b/revpi_provisioning/devices/PR100359R00.yaml
@@ -1,1 +1,5 @@
-_core.yaml
+---
+network_interfaces:
+  - type: lan95xx
+    path: 1-1.1:1.0
+    eeprom: False

--- a/revpi_provisioning/devices/PR100359R01.yaml
+++ b/revpi_provisioning/devices/PR100359R01.yaml
@@ -1,1 +1,9 @@
-_core-2022.yaml
+---
+hat_eeprom:
+  wp_gpio: 2
+  wp_gpiochip: gpiochip0
+
+network_interfaces:
+  - type: lan95xx
+    path: 1-1.1:1.0
+    eeprom: True

--- a/revpi_provisioning/devices/PR100360R00.yaml
+++ b/revpi_provisioning/devices/PR100360R00.yaml
@@ -1,1 +1,5 @@
-_core.yaml
+---
+network_interfaces:
+  - type: lan95xx
+    path: 1-1.1:1.0
+    eeprom: False

--- a/revpi_provisioning/devices/PR100360R01.yaml
+++ b/revpi_provisioning/devices/PR100360R01.yaml
@@ -1,1 +1,9 @@
-_core-2022.yaml
+---
+hat_eeprom:
+  wp_gpio: 2
+  wp_gpiochip: gpiochip0
+
+network_interfaces:
+  - type: lan95xx
+    path: 1-1.1:1.0
+    eeprom: True

--- a/revpi_provisioning/devices/PR100361R00.yaml
+++ b/revpi_provisioning/devices/PR100361R00.yaml
@@ -1,1 +1,5 @@
-_core.yaml
+---
+network_interfaces:
+  - type: lan95xx
+    path: 1-1.1:1.0
+    eeprom: False

--- a/revpi_provisioning/devices/PR100361R01.yaml
+++ b/revpi_provisioning/devices/PR100361R01.yaml
@@ -1,1 +1,9 @@
-_core-2022.yaml
+---
+hat_eeprom:
+  wp_gpio: 2
+  wp_gpiochip: gpiochip0
+
+network_interfaces:
+  - type: lan95xx
+    path: 1-1.1:1.0
+    eeprom: True

--- a/revpi_provisioning/devices/PR100365R00.yaml
+++ b/revpi_provisioning/devices/PR100365R00.yaml
@@ -1,1 +1,9 @@
-_core-2022.yaml
+---
+hat_eeprom:
+  wp_gpio: 2
+  wp_gpiochip: gpiochip0
+
+network_interfaces:
+  - type: lan95xx
+    path: 1-1.1:1.0
+    eeprom: True

--- a/revpi_provisioning/devices/PR100366R00.yaml
+++ b/revpi_provisioning/devices/PR100366R00.yaml
@@ -1,1 +1,9 @@
-_core-2022.yaml
+---
+hat_eeprom:
+  wp_gpio: 2
+  wp_gpiochip: gpiochip0
+
+network_interfaces:
+  - type: lan95xx
+    path: 1-1.1:1.0
+    eeprom: True

--- a/revpi_provisioning/devices/PR100367R00.yaml
+++ b/revpi_provisioning/devices/PR100367R00.yaml
@@ -1,1 +1,9 @@
-_core-2022.yaml
+---
+hat_eeprom:
+  wp_gpio: 2
+  wp_gpiochip: gpiochip0
+
+network_interfaces:
+  - type: lan95xx
+    path: 1-1.1:1.0
+    eeprom: True

--- a/revpi_provisioning/devices/_core-2022.yaml
+++ b/revpi_provisioning/devices/_core-2022.yaml
@@ -1,9 +1,0 @@
----
-hat_eeprom:
-  wp_gpio: 2
-  wp_gpiochip: gpiochip0
-
-network_interfaces:
-  - type: lan95xx
-    path: 1-1.1:1.0
-    eeprom: True

--- a/revpi_provisioning/devices/_core.yaml
+++ b/revpi_provisioning/devices/_core.yaml
@@ -1,5 +1,0 @@
----
-network_interfaces:
-  - type: lan95xx
-    path: 1-1.1:1.0
-    eeprom: False


### PR DESCRIPTION
Device yaml files have to be handled in MS Windows environment. The Windows NTFS filesystem doesn't understand symbolic links, which leads to broken files on the target afterwards.