### PR TITLE
CI: Run validation on pull-requests too

### DIFF
--- a/.github/workflows/validate-device-config-files.yml
+++ b/.github/workflows/validate-device-config-files.yml
@@ -1,6 +1,7 @@
 name: Device configuration files
 
-on: [push]
+on:
+  - pull_request
 
 jobs:
   validate:


### PR DESCRIPTION
I noticed that the yaml validation only runs on push, but not on pull-requests. In the past this went unnoticed because this repo was private and therefore all pull-requests where based on branches of this repo. With the repo beeing public and therefore forked external repos which are used in PRs like #11 we need to change this to the pull-request trigger.