### PR TITLE
feat: Introduce switch for verbose output in cli [REVPI-2834]

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,16 @@ The main purpose of this repository is the device provisioning during our EOL te
 The wrapper script writes the HAT eeprom contents, sets the mac address and probably other stuff in the future.
 
 ```
-usage: provisioner.py [-h] product-number mac-address eep-image
+usage: provisioner.py [-h] [-v] product-number mac-address eep-image
 provisioner.py: error: the following arguments are required: product-number, mac-address, eep-image
 ```
+
+> **_NOTE:_** Verbose output with optional information can be enabled with the `-v` switch.
 
 ### Dump HAT eeprom contents
 
 ```
-usage: dump_hat.py [-h] product-number output-file
+usage: dump_hat.py [-h] [-v] product-number output-file
 dump_hat.py: error: the following arguments are required: product-number, output-file
 ```
 
@@ -25,10 +27,13 @@ Example:
 sudo python3 -m revpi_provisioning.cli.dump_hat PR100383R00 hat.eep
 ```
 
+> **_NOTE:_** Verbose output with optional information can be enabled with the `-v` switch.
+
 ### Clear HAT eeprom contents
 
+
 ```
-usage: clear_hat.py [-h] product-number
+usage: clear_hat.py [-h] [-v] product-number
 clear_hat.py: error: the following arguments are required: product-number
 ```
 
@@ -36,3 +41,5 @@ Example:
 ```
 sudo python3 -m revpi_provisioning.cli.clear_hat PR100383R00
 ```
+
+> **_NOTE:_** Verbose output with optional information can be enabled with the `-v` switch.

--- a/revpi_provisioning/cli/clear_hat.py
+++ b/revpi_provisioning/cli/clear_hat.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 
+
 import argparse
 import sys
 
-from revpi_provisioning.cli.utils import error
+import revpi_provisioning.cli.utils
+from revpi_provisioning.cli.utils import error, verboseprint
 from revpi_provisioning.config import EOLConfigException, load_config
 from revpi_provisioning.hat import HatEEPROM, HatEEPROMWriteException
 from revpi_provisioning.revpi import RevPi
@@ -11,6 +13,13 @@ from revpi_provisioning.utils import extract_product
 
 
 def parse_args() -> tuple:
+    """Parse CLI args.
+
+    Returns
+    -------
+    tuple
+        CLI args
+    """
     parser = argparse.ArgumentParser(description="Clear RevPi HAT EEPROM")
 
     parser.add_argument(
@@ -18,20 +27,30 @@ def parse_args() -> tuple:
         metavar="product-number",
         help="product number of target device in format PRxxxxxxRxx",
     )
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", default=False, required=False
+    )
     args = parser.parse_args()
 
-    return args.product_number
+    return args.product_number, args.verbose
 
 
 def main() -> int:
-    product = parse_args()
+    """Run the actual program logic.
 
-    print(f"Starting device provisioning for product '{product}'")
+    Returns
+    -------
+    int
+        return code of the program
+    """
+    product, verbose = parse_args()
+
+    revpi_provisioning.cli.utils.verbose = verbose
 
     try:
-        print("Loading device configuration ... ", end="")
+        verboseprint("Loading device configuration ... ", end="")
         configuration = load_config(product)
-        print("OK")
+        verboseprint("OK")
 
         revpi = RevPi(*extract_product(product))
 
@@ -43,9 +62,9 @@ def main() -> int:
             )
 
         if revpi.hat_eeprom:
-            print("Clear HAT EEPROM ... ", end="")
+            verboseprint("Clear HAT EEPROM ... ", end="")
             revpi.clear_hat_eeprom()
-            print("OK")
+            verboseprint("OK")
 
     except EOLConfigException as ce:
         print("FAILED")

--- a/revpi_provisioning/cli/dump_hat.py
+++ b/revpi_provisioning/cli/dump_hat.py
@@ -3,7 +3,8 @@
 import argparse
 import sys
 
-from revpi_provisioning.cli.utils import error
+import revpi_provisioning.cli.utils
+from revpi_provisioning.cli.utils import error, verboseprint
 from revpi_provisioning.config import EOLConfigException, load_config
 from revpi_provisioning.hat import HatEEPROM, HatEEPROMWriteException
 from revpi_provisioning.revpi import RevPi
@@ -11,6 +12,13 @@ from revpi_provisioning.utils import extract_product
 
 
 def parse_args() -> tuple:
+    """Parse CLI args.
+
+    Returns
+    -------
+    tuple
+        CLI args
+    """
     parser = argparse.ArgumentParser(description="Clear RevPi HAT EEPROM")
 
     parser.add_argument(
@@ -23,20 +31,29 @@ def parse_args() -> tuple:
         metavar="output-file",
         help="output file where the HAT eeprom contents are written to",
     )
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", default=False, required=False
+    )
     args = parser.parse_args()
 
-    return args.product_number, args.output_file
+    return args.product_number, args.output_file, args.verbose
 
 
 def main() -> int:
-    product, output_file = parse_args()
+    """Run the actual program logic.
 
-    print(f"Starting device provisioning for product '{product}'")
+    Returns
+    -------
+    int
+        return code of the program
+    """
+    product, output_file, verbose = parse_args()
+    revpi_provisioning.cli.utils.verbose = verbose
 
     try:
-        print("Loading device configuration ... ", end="")
+        verboseprint("Loading device configuration ... ", end="")
         configuration = load_config(product)
-        print("OK")
+        verboseprint("OK")
 
         revpi = RevPi(*extract_product(product))
 
@@ -48,9 +65,9 @@ def main() -> int:
             )
 
         if revpi.hat_eeprom:
-            print("Dump HAT EEPROM ... ", end="")
+            verboseprint("Dump HAT EEPROM ... ", end="")
             revpi.dump_hat_eeprom(output_file)
-            print("OK")
+            verboseprint("OK")
 
     except EOLConfigException as ce:
         print("FAILED")

--- a/revpi_provisioning/cli/utils.py
+++ b/revpi_provisioning/cli/utils.py
@@ -1,8 +1,18 @@
 import sys
 
 
+global verbose
+verbose = False
+
+
 def error(msg: str, rc: int) -> None:
     """Print error message to STDERR and return with given return code."""
     print(msg, file=sys.stderr)
 
     return rc
+
+
+def verboseprint(*args: str, **kwargs: dict) -> None:
+    """Print only if verbose mode is enabled."""
+    if verbose:
+        print(*args, **kwargs)


### PR DESCRIPTION
Introduce an optional verbose switch, in order to simplify the output of the cli scripts. Without verbose switch only necessary information and errors are shown to the user.